### PR TITLE
fix: Pass GOOGLE_CLOUD_PROJECT env var to Gemini CLI subprocess

### DIFF
--- a/gemini_helper.py
+++ b/gemini_helper.py
@@ -146,6 +146,11 @@ def execute_gemini_cli(prompt: str, model_name: str = None, show_progress: bool 
             print("-" * 50, file=sys.stderr)
         
         # Use Popen for real-time streaming - SECURE VERSION (no shell=True)
+        # Include GOOGLE_CLOUD_PROJECT if it's set
+        env = {"PATH": os.environ.get("PATH", "")}
+        if "GOOGLE_CLOUD_PROJECT" in os.environ:
+            env["GOOGLE_CLOUD_PROJECT"] = os.environ["GOOGLE_CLOUD_PROJECT"]
+        
         process = subprocess.Popen(
             cmd_args,
             shell=False,
@@ -154,7 +159,7 @@ def execute_gemini_cli(prompt: str, model_name: str = None, show_progress: bool 
             text=True,
             bufsize=1,  # Line buffered
             universal_newlines=True,
-            env={"PATH": os.environ.get("PATH", "")},  # Minimal environment
+            env=env,  # Include necessary environment variables
             cwd=None  # Use current working directory
         )
         

--- a/gemini_mcp_server.py
+++ b/gemini_mcp_server.py
@@ -243,11 +243,16 @@ async def execute_gemini_cli_streaming(prompt: str, task_type: str = "gemini_qui
         cmd_args = ["gemini", "-m", model_name, "-p", prompt]
         logger.info(f"Executing command: gemini -m {model_name} -p [prompt length: {len(prompt)}]")
         
+        # Include GOOGLE_CLOUD_PROJECT if it's set
+        env = {"PATH": os.environ.get("PATH", "")}
+        if "GOOGLE_CLOUD_PROJECT" in os.environ:
+            env["GOOGLE_CLOUD_PROJECT"] = os.environ["GOOGLE_CLOUD_PROJECT"]
+        
         process = await asyncio.create_subprocess_exec(
             *cmd_args,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            env={"PATH": os.environ.get("PATH", "")}  # Minimal environment
+            env=env  # Include necessary environment variables
         )
         logger.info(f"Process created with PID: {process.pid}")
         


### PR DESCRIPTION
- Modified gemini_helper.py and gemini_mcp_server.py to include GOOGLE_CLOUD_PROJECT environment variable when calling Gemini CLI
- Fixes authentication error when using Gemini CLI through MCP server
- Now properly inherits GOOGLE_CLOUD_PROJECT from MCP server config

🤖 Generated with [Claude Code](https://claude.ai/code)